### PR TITLE
Publications page

### DIFF
--- a/lib/modules/apostrophe-blog-pages/views/index.html
+++ b/lib/modules/apostrophe-blog-pages/views/index.html
@@ -2,7 +2,7 @@
 
 {% import 'macros/blogMacros.html' as blog %}
 
-{% block title %} Best Evidence | {{ data.page.title | e }}{% endblock %}
+{% block title %}Best Evidence | {{ data.page.title | e }}{% endblock %}
 
 {% import 'apostrophe-pager:macros.html' as pager %}
 

--- a/lib/modules/apostrophe-blog-pages/views/index.html
+++ b/lib/modules/apostrophe-blog-pages/views/index.html
@@ -2,7 +2,7 @@
 
 {% import 'macros/blogMacros.html' as blog %}
 
-{% block title %} Quodl | {{ data.page.title | e }}{% endblock %}
+{% block title %} Best Evidence | {{ data.page.title | e }}{% endblock %}
 
 {% import 'apostrophe-pager:macros.html' as pager %}
 

--- a/lib/modules/apostrophe-blog-pages/views/index.html
+++ b/lib/modules/apostrophe-blog-pages/views/index.html
@@ -2,7 +2,7 @@
 
 {% import 'macros/blogMacros.html' as blog %}
 
-{% block title %}Best Evidence | {{ data.page.title | e }}{% endblock %}
+{% block title %} Quodl | {{ data.page.title | e }}{% endblock %}
 
 {% import 'apostrophe-pager:macros.html' as pager %}
 

--- a/lib/modules/apostrophe-search/views/index.html
+++ b/lib/modules/apostrophe-search/views/index.html
@@ -27,7 +27,6 @@
           {% endfor %}
         </ul>
       {% endif %}
-
       <input type="search" data-apos-search-field class="bn be-bg-white w-90 w-60-ns h3 br-pill pl3 pl4-ns shadow-2" value="{{ data.query.q | e }}" name="q" placeholder="Search Publications" />
       <input type="submit" value="" class="search ml1" alt="magnifying glass" />
     </form>

--- a/lib/modules/as-helpers/index.js
+++ b/lib/modules/as-helpers/index.js
@@ -2,7 +2,7 @@ var h2p = require('html2plaintext');
 
 module.exports = {
   extend: 'apostrophe-module',
-  alias: 'quodl',
+  alias: 'bestEvidence',
 
   construct: function(self, options) {
     self.addHelpers({

--- a/lib/modules/as-helpers/index.js
+++ b/lib/modules/as-helpers/index.js
@@ -2,7 +2,7 @@ var h2p = require('html2plaintext');
 
 module.exports = {
   extend: 'apostrophe-module',
-  alias: 'best-evidence',
+  alias: 'quodl',
 
   construct: function(self, options) {
     self.addHelpers({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "quodl-site",
+  "name": "bestEvidence-site",
   "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "best-evidence-site",
+  "name": "quodl-site",
   "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/views/macros/blogMacros.html
+++ b/views/macros/blogMacros.html
@@ -16,7 +16,7 @@
     <li class="dib w-49-ns bg-white v-top ph2-ns pb4">
       <span class="be-black f5 no-underline o-50 pb0">{{ piece.publishedAt | date('MMMM DD, YYYY' ) }}</span>
       <h4 class="mv1"><a href="{{ piece._url }}" class="be-black no-underline f3">{{ piece.title | e }}</a></h4>
-      <p class="mv0 f5 be-black">{{ apos.quodl.areaToPlainText(piece, 'main') | truncate(100) }}</p>
+      <p class="mv0 f5 be-black">{{ apos.bestEvidence.areaToPlainText(piece, 'main') | truncate(100) }}</p>
       {% if piece._author.title%}
       <p class="mv0 f5 be-red fw3">{{ piece._author.title }}</p>
       {% endif %}
@@ -30,8 +30,7 @@
     <span class="o-50 b">{{ piece.publishedAt | date('MMMM D, YYYY') }}</span>
     <a href="{{ piece._url }}" class="no-underline">
       <h6 class="f4 be-black mv3 lh-copy">{{ piece.title }}</h6>
-      <p class="mv0 be-black word-break-all">{{ apos.quodl.areaToPlainText(piece, 'main') | truncate(100) }}</p>
-
+      <p class="mv0 be-black word-break-all">{{ apos.bestEvidence.areaToPlainText(piece, 'main') | truncate(100) }}</p>
       {% if piece.authorId %}
         <span class="">{{ piece._author.title }}</span>
       {% endif %}

--- a/views/macros/blogMacros.html
+++ b/views/macros/blogMacros.html
@@ -16,7 +16,7 @@
     <li class="dib w-49-ns bg-white v-top ph2-ns pb4">
       <span class="be-black f5 no-underline o-50 pb0">{{ piece.publishedAt | date('MMMM DD, YYYY' ) }}</span>
       <h4 class="mv1"><a href="{{ piece._url }}" class="be-black no-underline f3">{{ piece.title | e }}</a></h4>
-      <p class="mv0 f5 be-black">{{ apos.best-evidence.areaToPlainText(piece, 'main') | truncate(100) }}</p>
+      <p class="mv0 f5 be-black">{{ apos.quodl.areaToPlainText(piece, 'main') | truncate(100) }}</p>
       {% if piece._author.title%}
       <p class="mv0 f5 be-red fw3">{{ piece._author.title }}</p>
       {% endif %}
@@ -30,7 +30,7 @@
     <span class="o-50 b">{{ piece.publishedAt | date('MMMM D, YYYY') }}</span>
     <a href="{{ piece._url }}" class="no-underline">
       <h6 class="f4 be-black mv3 lh-copy">{{ piece.title }}</h6>
-      <p class="mv0 be-black word-break-all">{{ apos.best-evidence.areaToPlainText(piece, 'main') | truncate(100) }}</p>
+      <p class="mv0 be-black word-break-all">{{ apos.quodl.areaToPlainText(piece, 'main') | truncate(100) }}</p>
 
       {% if piece.authorId %}
         <span class="">{{ piece._author.title }}</span>


### PR DESCRIPTION
#22 
Fixes error on the publications page. Page was returning with an apostrophe error stating that the template was unable to be rendered. 
The issue was in the naming convention of best-evidence, bestEvidence as one word had to be used instead. As apostrophe considers a hyphenated word to be two separate words.